### PR TITLE
27 - Allow Prettier to autoformat locally - Baz

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-	"editor.formatOnSave": false,
+	"editor.formatOnSave": true,
 	"editor.codeActionsOnSave": {
 		"source.fixAll.eslint": true
 	},


### PR DESCRIPTION
## Description

Currently Prettier does not seem to be autoformatting Locally.
There is a `.vscode` folder and inside of that is a `settings.json` that overrides the local VSCode settings.
One of the rules is `editor.formatOnSave: false`.
That rule has been adjusted to `true`.
This should allow developers Prettier to autoformat on save locally.

## Related to
Fixes #27 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have carefully reviewed my own code
- [x] ~I have commented my code~
- [x] I have updated any documentation
