### PR TITLE
59 - Header Navigation Adjustments - Baz

### DIFF
--- a/client/src/components/Header/Header.css
+++ b/client/src/components/Header/Header.css
@@ -11,7 +11,7 @@ header nav {
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	background-color: hsla(0, 0%, 70%, 0.92);
+	background-color: hsla(0, 0%, 70%, 0.96);
 	transform: translateY(-100vh);
 }
 
@@ -41,7 +41,8 @@ header nav ul {
 .navigation-link {
 	color: var(--black);
 	text-decoration: none;
-	font-size: 14px;
+	font-size: 18px;
+	font-weight: 600;
 	transition: all ease-in-out 200ms;
 }
 
@@ -57,34 +58,47 @@ header nav ul {
 	display: none; /* Hide the arrow by default */
 }
 
-/* hamburger button */
+/* to style both versions of the mobile navigation menu buttons: open ≡ and close X */
 .navigation-menu-button {
-	padding: 5px;
-	cursor: pointer;
-	background: transparent;
-	border: none;
-	outline: none;
-	font-size: 1.8rem;
 	display: block;
+	outline: none;
+	border: none;
+	background: transparent;
 	color: var(--black);
+	cursor: pointer;
 }
 
-/* close mobile menu button */
+/* to position the mobile navigation menu X close button */
 .navigation-menu-button-close {
 	position: absolute;
-	top: 18px;
-	right: 20px;
+	top: 24px;
+	right: 16px;
 }
 
+/* the style of the mobile navigation menu ≡ open icon  */
+.navigation-menu-button-icon {
+	font-size: 20px;
+}
+
+/* the style of the mobile navigation menu X close icon  */
+.navigation-menu-button-icon-close {
+	font-size: 26px;
+}
+
+/* mobile navigation menu (on open) */
 .navigation-open {
-	transform: none;
-	transition: 1s;
 	overflow: hidden;
+	transform: none;
+	transition: 0.7s;
+	/* make sure it is on top of all other elements */
+	z-index: 3;
 }
 
-/* transition for closing mobile navbar */
+/* mobile navigation menu (on close) */
 .navigation-closing {
-	transition: 1s;
+	transition: 0.7s;
+	/* make sure it is on top of all other elements */
+	z-index: 3;
 }
 
 .header-logo-container {

--- a/client/src/components/Header/Header.jsx
+++ b/client/src/components/Header/Header.jsx
@@ -96,11 +96,11 @@ const Header = () => {
 						className="navigation-menu-button navigation-menu-button-close"
 						onClick={closeNavbar}
 					>
-						<FaTimes />
+						<FaTimes className="navigation-menu-button-icon-close" />
 					</button>
 				</nav>
 				<button className="navigation-menu-button" onClick={showNavbar}>
-					<FaBars />
+					<FaBars className="navigation-menu-button-icon" />
 				</button>
 			</div>
 		</header>


### PR DESCRIPTION
## Issue
The Mobile Navigation is not the topmost element, so the images or maps etc are sitting above it.

BEFORE:
![image](https://github.com/ShayanMahnam/lentegeur-hospital-facility-board/assets/61154071/26bea605-72d1-4278-b985-482be9ecd8fe)
![image](https://github.com/ShayanMahnam/lentegeur-hospital-facility-board/assets/61154071/b11f396f-c22b-40d2-a638-8ffdc0c5672d)

## Description

This PR:
- adjusts the z-index of the Mobile Navigation in both Open/Opening and Closed/Closing States to be above the other elements.
- adjusts the styling of the open and close icons to make them a bit larger
- adjusts the styling of the mobile navigation links to make them a bit larger
- lowers the transition time
- increases the opacity
- removes some unneccessary css rules

AFTER:
![image](https://github.com/ShayanMahnam/lentegeur-hospital-facility-board/assets/61154071/6fbfb620-1f80-4485-b8ee-cbbeaf431cf6)
![image](https://github.com/ShayanMahnam/lentegeur-hospital-facility-board/assets/61154071/bff5ca7a-6054-4fd7-88df-15a63544a958)

## Related to

Fixes #59 

## Checklist:

- [X] My code follows the style guidelines of this project
- [ ] I have carefully reviewed my own code
- [X] I have commented my code
- [X] ~I have updated any documentation~
