### PR TITLE
41 - Create Database Models - Baz

### DIFF
--- a/server/src/api/event/content-types/event/schema.json
+++ b/server/src/api/event/content-types/event/schema.json
@@ -1,0 +1,94 @@
+{
+  "kind": "collectionType",
+  "collectionName": "events",
+  "info": {
+    "singularName": "event",
+    "pluralName": "events",
+    "displayName": "Event",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true,
+      "unique": true,
+      "minLength": 3
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "title",
+      "required": true,
+      "minLength": 3
+    },
+    "startDate": {
+      "type": "date",
+      "required": true
+    },
+    "endDate": {
+      "type": "date",
+      "required": false
+    },
+    "startTime": {
+      "type": "time",
+      "required": true
+    },
+    "endTime": {
+      "type": "time"
+    },
+    "location": {
+      "type": "string",
+      "required": true,
+      "minLength": 3
+    },
+    "category": {
+      "type": "enumeration",
+      "enum": [
+        "category1",
+        "category2",
+        "category3",
+        "category4",
+        "category5",
+        "category6"
+      ],
+      "required": true
+    },
+    "tags": {
+      "type": "customField",
+      "options": [
+        "tag1",
+        "tag2",
+        "tag3",
+        "tag4",
+        "tag5",
+        "tag6"
+      ],
+      "customField": "plugin::multi-select.multi-select"
+    },
+    "summary": {
+      "type": "string",
+      "required": true,
+      "minLength": 3,
+      "maxLength": 200
+    },
+    "content": {
+      "type": "customField",
+      "options": {
+        "preset": "toolbar"
+      },
+      "customField": "plugin::ckeditor5.CKEditor",
+      "required": true
+    },
+    "images": {
+      "type": "media",
+      "multiple": true,
+      "required": true,
+      "allowedTypes": [
+        "images"
+      ]
+    }
+  }
+}

--- a/server/src/api/event/controllers/event.js
+++ b/server/src/api/event/controllers/event.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * event controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::event.event');

--- a/server/src/api/event/routes/event.js
+++ b/server/src/api/event/routes/event.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * event router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::event.event');

--- a/server/src/api/event/services/event.js
+++ b/server/src/api/event/services/event.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * event service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::event.event');

--- a/server/src/api/gallery-album/content-types/gallery-album/schema.json
+++ b/server/src/api/gallery-album/content-types/gallery-album/schema.json
@@ -1,0 +1,66 @@
+{
+  "kind": "collectionType",
+  "collectionName": "gallery_albums",
+  "info": {
+    "singularName": "gallery-album",
+    "pluralName": "gallery-albums",
+    "displayName": "Gallery Album",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true,
+      "unique": true,
+      "minLength": 3
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "title",
+      "required": true,
+      "minLength": 3
+    },
+    "category": {
+      "type": "enumeration",
+      "enum": [
+        "category1",
+        "category2",
+        "category3",
+        "category4",
+        "category5",
+        "category6"
+      ],
+      "required": true
+    },
+    "tags": {
+      "type": "customField",
+      "options": [
+        "tag1",
+        "tag2",
+        "tag3",
+        "tag4",
+        "tag5",
+        "tag6"
+      ],
+      "customField": "plugin::multi-select.multi-select"
+    },
+    "summary": {
+      "type": "string",
+      "maxLength": 200,
+      "minLength": 3,
+      "required": true
+    },
+    "images": {
+      "allowedTypes": [
+        "images"
+      ],
+      "type": "media",
+      "multiple": true,
+      "required": true
+    }
+  }
+}

--- a/server/src/api/gallery-album/controllers/gallery-album.js
+++ b/server/src/api/gallery-album/controllers/gallery-album.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * gallery-album controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::gallery-album.gallery-album');

--- a/server/src/api/gallery-album/routes/gallery-album.js
+++ b/server/src/api/gallery-album/routes/gallery-album.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * gallery-album router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::gallery-album.gallery-album');

--- a/server/src/api/gallery-album/services/gallery-album.js
+++ b/server/src/api/gallery-album/services/gallery-album.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * gallery-album service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::gallery-album.gallery-album');

--- a/server/src/api/news-article/content-types/news-article/schema.json
+++ b/server/src/api/news-article/content-types/news-article/schema.json
@@ -1,0 +1,77 @@
+{
+  "kind": "collectionType",
+  "collectionName": "news_articles",
+  "info": {
+    "singularName": "news-article",
+    "pluralName": "news-articles",
+    "displayName": "News Article",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true,
+      "unique": true,
+      "minLength": 3
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "title",
+      "required": true,
+      "minLength": 3
+    },
+    "date": {
+      "type": "date",
+      "required": true
+    },
+    "category": {
+      "type": "enumeration",
+      "enum": [
+        "category1",
+        "category2",
+        "category3",
+        "category4",
+        "category5",
+        "category6"
+      ],
+      "required": true
+    },
+    "tags": {
+      "type": "customField",
+      "options": [
+        "tag1",
+        "tag2",
+        "tag3",
+        "tag4",
+        "tag5",
+        "tag6"
+      ],
+      "customField": "plugin::multi-select.multi-select"
+    },
+    "summary": {
+      "type": "string",
+      "required": true,
+      "maxLength": 200,
+      "minLength": 3
+    },
+    "content": {
+      "type": "customField",
+      "options": {
+        "preset": "toolbar"
+      },
+      "customField": "plugin::ckeditor5.CKEditor"
+    },
+    "images": {
+      "allowedTypes": [
+        "images"
+      ],
+      "type": "media",
+      "multiple": true,
+      "required": true
+    }
+  }
+}

--- a/server/src/api/news-article/controllers/news-article.js
+++ b/server/src/api/news-article/controllers/news-article.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * news-article controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::news-article.news-article');

--- a/server/src/api/news-article/routes/news-article.js
+++ b/server/src/api/news-article/routes/news-article.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * news-article router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::news-article.news-article');

--- a/server/src/api/news-article/services/news-article.js
+++ b/server/src/api/news-article/services/news-article.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * news-article service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::news-article.news-article');

--- a/server/src/api/service/content-types/service/schema.json
+++ b/server/src/api/service/content-types/service/schema.json
@@ -1,0 +1,74 @@
+{
+  "kind": "collectionType",
+  "collectionName": "services",
+  "info": {
+    "singularName": "service",
+    "pluralName": "services",
+    "displayName": "Service",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "minLength": 3,
+      "required": true
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "title",
+      "minLength": 3,
+      "required": true
+    },
+    "category": {
+      "type": "enumeration",
+      "enum": [
+        "category1",
+        "category2",
+        "category3",
+        "category4",
+        "category5",
+        "category6"
+      ],
+      "required": true
+    },
+    "tags": {
+      "type": "customField",
+      "options": [
+        "tag1",
+        "tag2",
+        "tag3",
+        "tag4",
+        "tag5",
+        "tag6"
+      ],
+      "customField": "plugin::multi-select.multi-select"
+    },
+    "summary": {
+      "type": "string",
+      "required": true,
+      "unique": false,
+      "maxLength": 200,
+      "minLength": 3
+    },
+    "content": {
+      "type": "customField",
+      "options": {
+        "preset": "toolbar"
+      },
+      "required": true,
+      "customField": "plugin::ckeditor5.CKEditor"
+    },
+    "images": {
+      "allowedTypes": [
+        "images"
+      ],
+      "type": "media",
+      "multiple": true,
+      "required": true
+    }
+  }
+}

--- a/server/src/api/service/controllers/service.js
+++ b/server/src/api/service/controllers/service.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * service controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::service.service');

--- a/server/src/api/service/routes/service.js
+++ b/server/src/api/service/routes/service.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * service router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::service.service');

--- a/server/src/api/service/services/service.js
+++ b/server/src/api/service/services/service.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * service service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::service.service');


### PR DESCRIPTION
## Description

This PR defines the data structures for the following database model/schemas:

- **News Article**
  - `title` - the title of the news article (required) [unique] [min length 3]
  - `slug` - the slugified version of the title eg. "some-news-title" (required) [min length 3]
  - `date` - the date of the news article (required)
  - `category` - the category of the news article - a single option from many (required)
  - `tags` - the tags associated with the news article - multiple options from many (optional)
  - `summary` - a short summary of the news article (required) (text field) [min length 3 & max length 200]
  - `content` - the main content of the news article (required) (rich text field editor)
  - `images` - the images for the news article (required) (image media upload)

- News Article **Query Examples**:
  - `/api/news-article`
  - `/api/news-article?populate=*`
  - `/api/news-article/1`
  - `/api/news-article/1?populate=*`

---

- **Event** `/api/event`
  - `title` - the title of the news article (required) [unique] [min length 3]
  - `slug` - the slugified version of the title eg. "some-event-title" (required) [min length 3]
  - `startDate` - the start date of the event (required)
  - `endDate` - the end date of the event (optional)
  - `startTime` - the start time of the event (required)
  - `endTime` - the end time of the event (optional)
  - `location` - the location of the event (required)
  - `category` - the category of the event - a single option from many (required)
  - `tags` - the tags associated with the event - multiple options from many (optional)
  - `summary` - a short summary of the event (required) (text field) [min length 3 & max length 200]
  - `content` - the main description of the event (required) (rich text field editor)
  - `images` - the images for the event (required) (image media upload)

- Event **Query Examples**:
  - `/api/event`
  - `/api/event?populate=*`
  - `/api/event/1`
  - `/api/event/1?populate=*`

---

- **Service** `/api/service`
  - `title` - the title of the service (required) [unique] [min length 3]
  - `slug` - the slugified version of the title eg. "some-service-title" (required) [min length 3]
  - `category` - the category of the service - a single option from many (required)
  - `tags` - the tags associated with the service - multiple options from many (optional)
  - `summary` - a short summary of the service (required) (text field) [min length 3 & max length 200]
  - `content` - the main description of the service (required) (rich text field editor)
  - `images` - the images for the service (required) (image media upload)

- Service**Query Examples**:
  - `/api/service`
  - `/api/service?populate=*`
  - `/api/service/1`
  - `/api/service/1?populate=*`

---

- **Gallery Album** `/api/gallery-album`
  - `title` - the title of the gallery album (required) [unique] [min length 3]
  - `slug` - the slugified version of the title eg. "some-service-title" (required) [min length 3]
  - `category` - the category of the gallery album - a single option from many (required)
  - `tags` - the tags associated with the gallery album - multiple options from many (optional)
  - `summary` - a short summary of the gallery album (required) (text field) [min length 3 & max length 200]
  - `images` - the images of the album (required) (image media upload)

- Gallery **Query Examples**:
  - `/api/gallery-album`
  - `/api/gallery-album?populate=*`
  - `/api/gallery-album/1`
  - `/api/gallery-album/1?populate=*`

---
   
## Related to

Fixes #41 

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have carefully reviewed my own code
- [X] ~I have commented my code~
- [X] I have updated any documentation
