### PR TITLE
79-added padding-bottom to service title-khadija

### DIFF
--- a/client/src/pages/ServicesPage/ServicesPage.css
+++ b/client/src/pages/ServicesPage/ServicesPage.css
@@ -1,3 +1,7 @@
 .services-page {
 	margin: 0 20px;
 }
+
+.services-page-title {
+	padding-bottom: 20px;
+}

--- a/client/src/pages/ServicesPage/ServicesPage.jsx
+++ b/client/src/pages/ServicesPage/ServicesPage.jsx
@@ -28,7 +28,7 @@ const servicesData = [
 const ServicesPage = () => {
 	return (
 		<div className="services-page">
-			<h1>Services</h1>
+			<h1 className="services-page-title">Services</h1>
 			{servicesData.map((service, index) => (
 				<Services
 					key={index}


### PR DESCRIPTION
## Description

For mobile first, the title is too close to the first service sub-heading.

Added padding bottom.

## Related to

Fixes #79 

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have carefully reviewed my own code
- [ ] I have commented my code
- [ ] I have updated any documentation
