### PR TITLE
97 - About Page Dynamic Content - Baz

### DIFF
--- a/client/src/pages/AboutPage/AboutPage.jsx
+++ b/client/src/pages/AboutPage/AboutPage.jsx
@@ -1,16 +1,57 @@
 import "./AboutPage.css";
+import Loading from "../../components/Loading/Loading";
+import ErrorComponent from "../../components/ErrorComponent/ErrorComponent";
 import HistorySection from "./components/HistorySection/HistorySection";
 import GovernanceSection from "./components/GovernanceSection/GovernanceSection";
 import NetworkingSection from "./components/NetworkingSection/NetworkingSection";
+import { useQuery } from "@tanstack/react-query";
 
 const AboutPage = () => {
+	const fetchAboutPageContent = async () => {
+		const response = await fetch(
+			`${import.meta.env.VITE_API_URL}/about-page?populate=images`
+		);
+		if (!response.ok) {
+			throw new Error("Network response was not ok");
+		}
+		return response.json();
+	};
+
+	const { isLoading, isError, data, error } = useQuery({
+		queryKey: ["about-page"],
+		queryFn: fetchAboutPageContent,
+	});
+	const aboutPageContent = data?.data;
+
+	const {
+		historySectionImage,
+		historySectionText,
+		governanceSectionText,
+		networkAffiliatesSectionImage,
+		networkAffiliatesSectionText,
+		networkAffiliatesSectionLogos,
+	} = aboutPageContent;
+
 	return (
-		<div className="about-page">
-			<h1>About</h1>
-			<HistorySection />
-			<GovernanceSection />
-			<NetworkingSection />
-		</div>
+		<>
+			{isLoading && <Loading />}
+			{isError && <ErrorComponent error={error} />}
+			{!!aboutPageContent && (
+				<div className="about-page">
+					<h1>About</h1>
+					<HistorySection
+						historySectionImage={historySectionImage}
+						historySectionText={historySectionText}
+					/>
+					<GovernanceSection governanceSectionText={governanceSectionText} />
+					<NetworkingSection
+						networkAffiliatesSectionImage={networkAffiliatesSectionImage}
+						networkAffiliatesSectionText={networkAffiliatesSectionText}
+						networkAffiliatesSectionLogos={networkAffiliatesSectionLogos}
+					/>
+				</div>
+			)}
+		</>
 	);
 };
 

--- a/client/src/pages/AboutPage/AboutPage.jsx
+++ b/client/src/pages/AboutPage/AboutPage.jsx
@@ -7,9 +7,9 @@ import NetworkingSection from "./components/NetworkingSection/NetworkingSection"
 import { useQuery } from "@tanstack/react-query";
 
 const AboutPage = () => {
-	const fetchAboutPageContent = async () => {
+	const fetchAboutPage = async () => {
 		const response = await fetch(
-			`${import.meta.env.VITE_API_URL}/about-page?populate=images`
+			`${import.meta.env.VITE_API_URL}/about-page?populate=*`
 		);
 		if (!response.ok) {
 			throw new Error("Network response was not ok");
@@ -17,9 +17,9 @@ const AboutPage = () => {
 		return response.json();
 	};
 
-	const { isLoading, isError, data, error } = useQuery({
+	const { isLoading, isError, isSuccess, data, error } = useQuery({
 		queryKey: ["about-page"],
-		queryFn: fetchAboutPageContent,
+		queryFn: fetchAboutPage,
 	});
 	const aboutPageContent = data?.data;
 
@@ -30,13 +30,14 @@ const AboutPage = () => {
 		networkAffiliatesSectionImage,
 		networkAffiliatesSectionText,
 		networkAffiliatesSectionLogos,
-	} = aboutPageContent;
+	} = aboutPageContent || {};
+	// the || {} is to prevent a destructuring error since "data" maybe undefined
 
 	return (
 		<>
 			{isLoading && <Loading />}
 			{isError && <ErrorComponent error={error} />}
-			{!!aboutPageContent && (
+			{isSuccess && (
 				<div className="about-page">
 					<h1>About</h1>
 					<HistorySection

--- a/client/src/pages/AboutPage/components/Affiliate/Affiliate.css
+++ b/client/src/pages/AboutPage/components/Affiliate/Affiliate.css
@@ -1,34 +1,37 @@
-.affiliates {
+.networking-affiliates-container {
 	display: grid;
 	grid-template-columns: 1fr;
 	justify-content: center;
 	align-items: center;
 }
 
-.affiliates .affiliate {
+.networking-affiliate {
 	display: flex;
 	align-items: center;
 	gap: 10px;
 	margin-bottom: 10px;
 }
 
-.affiliate-image-container {
+.networking-affiliate-image-container {
 	width: 50px;
 }
 
-.affiliate-image-container img {
+.networking-affiliate-image {
 	width: 100%;
 	height: 100%;
 	object-fit: cover;
 }
 
-/* tablet */
+.networking-affiliate-name {
+	/* placeholder */
+}
+
 @media screen and (min-width: 480px) {
-	.affiliates {
+	.networking-affiliates-container {
 		grid-template-columns: 1fr 1fr;
 	}
 
-	.affiliates .affiliate {
+	.networking-affiliate {
 		justify-content: center;
 	}
 }

--- a/client/src/pages/AboutPage/components/Affiliate/Affiliate.jsx
+++ b/client/src/pages/AboutPage/components/Affiliate/Affiliate.jsx
@@ -1,12 +1,16 @@
 import "./Affiliate.css";
 
-const Affiliate = ({ image, name, altText }) => {
+const Affiliate = ({ url, alternativeText }) => {
 	return (
-		<div className="affiliate">
-			<div className="affiliate-image-container">
-				<img src={image} alt={altText} />
+		<div className="networking-affiliate">
+			<div className="networking-affiliate-image-container">
+				<img
+					src={url}
+					alt={alternativeText}
+					className="networking-affiliate-image"
+				/>
 			</div>
-			<p>{name}</p>
+			<p className="networking-affiliate-name">{alternativeText}</p>
 		</div>
 	);
 };

--- a/client/src/pages/AboutPage/components/GovernanceSection/GovernanceSection.css
+++ b/client/src/pages/AboutPage/components/GovernanceSection/GovernanceSection.css
@@ -7,3 +7,7 @@
 	flex-direction: column;
 	gap: 10px;
 }
+
+.governance-text-container {
+	/* placeholder */
+}

--- a/client/src/pages/AboutPage/components/GovernanceSection/GovernanceSection.jsx
+++ b/client/src/pages/AboutPage/components/GovernanceSection/GovernanceSection.jsx
@@ -1,37 +1,14 @@
 import "./GovernanceSection.css";
 import Line from "../../../../components/Line/Line";
+import parseContent from "../../../../utils/parseContent";
 
-const GovernanceSection = () => {
+const GovernanceSection = ({ governanceSectionText }) => {
 	return (
 		<section className="governance-section">
 			<h2>Governance</h2>
 			<Line />
-			<div className="governance-container">
-				<p>
-					Lorem Ipsum is simply dummy text of the printing and typesetting
-					industry. Lorem Ipsum has been the industrys standard dummy text ever
-					since the 1500s, when an unknown printer took a galley of type and
-					scrambled it to make a type specimen book. It has survived not only
-					five centuries, but also the leap into electronic typesetting,
-					remaining essentially unchanged. It was popularised in the 1960s with
-					the release of Letraset sheets containing Lorem Ipsum passages, and
-					more recently with desktop publishing software like Aldus PageMaker
-					including versions of Lorem Ipsum.
-				</p>
-				<p>
-					Contrary to popular belief, Lorem Ipsum is not simply random text. It
-					has roots in a piece of classical Latin literature from 45 BC, making
-					it over 2000 years old. Richard McClintock, a Latin professor at
-					Hampden-Sydney College in Virginia, looked up one of the more obscure
-					Latin words, consectetur, from a Lorem Ipsum passage, and going
-					through the cites of the word in classical literature, discovered the
-					undoubtable source. Lorem Ipsum comes from sections 1.10.32 and
-					1.10.33 of de Finibus Bonorum et Malorum (The Extremes of Good and
-					Evil) by Cicero, written in 45 BC. This book is a treatise on the
-					theory of ethics, very popular during the Renaissance. The first line
-					of Lorem Ipsum, Lorem ipsum dolor sit amet.., comes from a line in
-					section 1.10.32.
-				</p>
+			<div className="governance-text-container">
+				{parseContent(governanceSectionText)}
 			</div>
 		</section>
 	);

--- a/client/src/pages/AboutPage/components/HistorySection/HistorySection.css
+++ b/client/src/pages/AboutPage/components/HistorySection/HistorySection.css
@@ -15,7 +15,7 @@
 	overflow: hidden;
 }
 
-.history-image-container img {
+.history-image {
 	width: 100%;
 	height: 100%;
 	object-fit: cover;
@@ -32,7 +32,7 @@
 		height: 250px;
 	}
 
-	.history-text {
+	.history-text-container {
 		width: 60%;
 	}
 }

--- a/client/src/pages/AboutPage/components/HistorySection/HistorySection.jsx
+++ b/client/src/pages/AboutPage/components/HistorySection/HistorySection.jsx
@@ -1,31 +1,25 @@
 import "./HistorySection.css";
 import Line from "../../../../components/Line/Line";
+import parseContent from "../../../../utils/parseContent";
 
-import image from "../../../HomePage/assets/slider02.jpg";
-
-const HistorySection = () => {
+const HistorySection = ({ historySectionImage, historySectionText }) => {
 	return (
-		<div className="history-section">
+		<section className="history-section">
 			<h2>History</h2>
 			<Line />
 			<div className="history-container">
 				<div className="history-image-container">
-					<img src={image} alt="grey square" />
+					<img
+						src={historySectionImage.url}
+						alt={historySectionImage.alternativeText}
+						className="history-image"
+					/>
 				</div>
-
-				<p className="history-text">
-					Lorem Ipsum is simply dummy text of the printing and typesetting
-					industry. Lorem Ipsum has been the industrys standard dummy text ever
-					since the 1500s, when an unknown printer took a galley of type and
-					scrambled it to make a type specimen book. It has survived not only
-					five centuries, but also the leap into electronic typesetting,
-					remaining essentially unchanged. It was popularised in the 1960s with
-					the release of Letraset sheets containing Lorem Ipsum passages, and
-					more recently with desktop publishing software like Aldus PageMaker
-					including versions of Lorem Ipsum.
-				</p>
+				<div className="history-text-container">
+					{parseContent(historySectionText)}
+				</div>
 			</div>
-		</div>
+		</section>
 	);
 };
 

--- a/client/src/pages/AboutPage/components/NetworkingSection/NetworkingSection.css
+++ b/client/src/pages/AboutPage/components/NetworkingSection/NetworkingSection.css
@@ -1,5 +1,5 @@
 .networking-section {
-	/*  */
+	/* placeholder */
 }
 
 .networking-container {
@@ -14,8 +14,12 @@
 	height: 150px;
 }
 
-.networking-image-container img {
+.networking-image {
 	width: 100%;
 	height: 100%;
 	object-fit: cover;
+}
+
+.networking-text-container {
+	/* placeholder */
 }

--- a/client/src/pages/AboutPage/components/NetworkingSection/NetworkingSection.jsx
+++ b/client/src/pages/AboutPage/components/NetworkingSection/NetworkingSection.jsx
@@ -1,17 +1,13 @@
 import "./NetworkingSection.css";
 import Line from "../../../../components/Line/Line";
 import Affiliate from "../Affiliate/Affiliate";
+import parseContent from "../../../../utils/parseContent";
 
-import placeholderNetworkingImage from "../../../../assets/grey_circle_image.svg";
-
-const NetworkingSection = () => {
-	//adding  6 affiliates to the array
-	const affiliates = Array.from({ length: 6 }, (_, index) => ({
-		name: `Affiliate Name ${index + 1}`,
-		image: placeholderNetworkingImage,
-		altText: `Affiliate alternate text ${index + 1}`,
-	}));
-
+const NetworkingSection = ({
+	networkAffiliatesSectionImage,
+	networkAffiliatesSectionText,
+	networkAffiliatesSectionLogos,
+}) => {
 	return (
 		<section className="networking-section">
 			<h2>Networking Affiliates</h2>
@@ -19,31 +15,22 @@ const NetworkingSection = () => {
 			<div className="networking-container">
 				<div className="networking-image-container">
 					<img
-						src={"https://i.ytimg.com/vi/Sx3hJS_JW1k/maxresdefault.jpg"}
-						alt="grey square"
+						src={networkAffiliatesSectionImage.url}
+						alt={networkAffiliatesSectionImage.alternativeText}
+						className="networking-image"
 					/>
 				</div>
-
-				<p>
-					Lorem Ipsum is simply dummy text of the printing and typesetting
-					industry. Lorem Ipsum has been the industrys standard dummy text ever
-					since the 1500s, when an unknown printer took a galley of type and
-					scrambled it to make a type specimen book. It has survived not only
-					five centuries, but also the leap into electronic typesetting,
-					remaining essentially unchanged. It was popularised in the 1960s with
-					the release of Letraset sheets containing Lorem Ipsum passages, and
-					more recently with desktop publishing software like Aldus PageMaker
-					including versions of Lorem Ipsum.
-				</p>
+				<div className="networking-text-container">
+					{parseContent(networkAffiliatesSectionText)}
+				</div>
 			</div>
-			<div className="affiliates">
-				{affiliates.length > 0 &&
-					affiliates.map((affiliate) => (
+			<div className="networking-affiliates-container">
+				{!!networkAffiliatesSectionLogos &&
+					networkAffiliatesSectionLogos.map((networkAffiliateLogo) => (
 						<Affiliate
-							key={affiliate.name}
-							image={affiliate.image}
-							name={affiliate.name}
-							altText={affiliate.altText}
+							key={networkAffiliateLogo.id}
+							url={networkAffiliateLogo.url}
+							alternativeText={networkAffiliateLogo.alternativeText}
 						/>
 					))}
 			</div>

--- a/server/src/api/about-page/content-types/about-page/schema.json
+++ b/server/src/api/about-page/content-types/about-page/schema.json
@@ -1,0 +1,58 @@
+{
+  "kind": "singleType",
+  "collectionName": "about_pages",
+  "info": {
+    "singularName": "about-page",
+    "pluralName": "about-pages",
+    "displayName": "AboutPage",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "historySectionImage": {
+      "allowedTypes": ["images"],
+      "type": "media",
+      "multiple": false,
+      "required": true
+    },
+    "historySectionText": {
+      "type": "customField",
+      "options": {
+        "preset": "toolbar"
+      },
+      "customField": "plugin::ckeditor5.CKEditor",
+      "required": true
+    },
+    "governanceSectionText": {
+      "type": "customField",
+      "options": {
+        "preset": "toolbar"
+      },
+      "customField": "plugin::ckeditor5.CKEditor",
+      "required": true
+    },
+    "networkAffiliatesSectionImage": {
+      "allowedTypes": ["images"],
+      "type": "media",
+      "multiple": false,
+      "required": true
+    },
+    "networkAffiliatesSectionText": {
+      "type": "customField",
+      "options": {
+        "preset": "toolbar"
+      },
+      "required": true,
+      "customField": "plugin::ckeditor5.CKEditor"
+    },
+    "networkAffiliatesSectionLogos": {
+      "type": "media",
+      "multiple": true,
+      "required": true,
+      "allowedTypes": ["images"]
+    }
+  }
+}

--- a/server/src/api/about-page/controllers/about-page.js
+++ b/server/src/api/about-page/controllers/about-page.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * about-page controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::about-page.about-page');

--- a/server/src/api/about-page/routes/about-page.js
+++ b/server/src/api/about-page/routes/about-page.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * about-page router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::about-page.about-page');

--- a/server/src/api/about-page/services/about-page.js
+++ b/server/src/api/about-page/services/about-page.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * about-page service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::about-page.about-page');


### PR DESCRIPTION
## Description

This PR converts the About Page from using hard coded/static Content to instead recieve Dynamic Content from the Strapi API.

The API route to recieve the About Page Content is `/api/about-page?populate=*`

the About Page API `response` consists of:
- `historySectionImage` [single image]
- `historySectionText` [rich text]
- `governanceSectionText` [rich text]
- `networkAffiliatesSectionImage` [single image]
- `networkAffiliatesSectionText` [rich text]
- `networkAffiliatesSectionLogos` [array of images]

## Issues

(a Loading Page rather than Component should be created/adjusted to reflect the new style of loading the entire Page.)

I am unable to add the Content to the Live Strapi API until this PR is merged

Please look at the shape of the Data in `/server/src/api/content-types/about-page/schema.json`

And here is a screenshot of a local development GET request to that route using PostMan:

![image](https://github.com/ShayanMahnam/lentegeur-hospital-facility-board/assets/61154071/d489cc79-52a2-4295-833a-dab3772d7877)

## Related to

Fixes #97 

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have carefully reviewed my own code
- [X] I have commented my code
- [X] ~I have updated any documentation~
