### PR TITLE
146- fix get involved section padding - khadija

### DIFF
--- a/client/src/pages/GetInvolvedPage/components/GetInvolvedSection/GetInvolvedSection.css
+++ b/client/src/pages/GetInvolvedPage/components/GetInvolvedSection/GetInvolvedSection.css
@@ -1,10 +1,5 @@
 .get-involved-section {
 	margin-bottom: 30px; /* to offset from the next section */
-	padding: 30px 20px;
-}
-
-.get-involved-title {
-	/* placeholder */
 }
 
 .get-involved-line {

--- a/client/src/pages/GetInvolvedPage/components/GetInvolvedSection/GetInvolvedSection.css
+++ b/client/src/pages/GetInvolvedPage/components/GetInvolvedSection/GetInvolvedSection.css
@@ -1,5 +1,6 @@
 .get-involved-section {
 	margin-bottom: 30px; /* to offset from the next section */
+	padding: 0 20px;
 }
 
 .get-involved-line {

--- a/client/src/pages/GetInvolvedPage/components/VolunteerSection/VolunteerSection.css
+++ b/client/src/pages/GetInvolvedPage/components/VolunteerSection/VolunteerSection.css
@@ -2,10 +2,6 @@
 	padding: 30px 20px;
 }
 
-.volunteer-title {
-	/* placeholder */
-}
-
 .volunteer-line {
 	background-color: black;
 }

--- a/client/src/pages/GetInvolvedPage/components/VolunteerSection/VolunteerSection.css
+++ b/client/src/pages/GetInvolvedPage/components/VolunteerSection/VolunteerSection.css
@@ -1,5 +1,5 @@
 .volunteer-section {
-	padding: 30px 20px;
+	padding: 0 20px;
 }
 
 .volunteer-line {

--- a/client/src/pages/HomePage/components/HomeEventsSection/HomeEventsSection.css
+++ b/client/src/pages/HomePage/components/HomeEventsSection/HomeEventsSection.css
@@ -1,5 +1,9 @@
 .home-events-section {
-	background: linear-gradient(0deg, rgba(0,70,67,1) 0%, rgba(172,201,157,1) 100%);
+	background: linear-gradient(
+		0deg,
+		rgba(0, 70, 67, 1) 0%,
+		rgba(172, 201, 157, 1) 100%
+	);
 	padding: 20px 0 10px 0;
 }
 


### PR DESCRIPTION
## Description

The padding in the get involved section pushes the title down which does not match the other pages.
I removed the padding and now it's the same level as the other pages.

## Related to

Make sure you include the issue number with a hash sign # so Github can link this PR to the right issue, like this:

Fixes #146 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have carefully reviewed my own code
- [x] I have commented my code
- [x] I have updated any documentation
