### PR TITLE
158 - Home Page Subheading Links - Baz

### DIFF
--- a/client/src/pages/HomePage/HomePage.css
+++ b/client/src/pages/HomePage/HomePage.css
@@ -3,18 +3,6 @@
 	flex-direction: column;
 }
 
-.home-page-divider-one {
-	background-color: hsl(126, 73%, 30%);
-	/* height: 15px; */
-	height: 10px;
-}
-
-.home-page-divider-two {
-	background-color: hsl(126, 73%, 30%);
-	/* height: 15px; */
-	height: 15px;
-}
-
 @media screen and (min-width: 768px) {
 	.home-page {
 		/* placeholder */

--- a/client/src/pages/HomePage/HomePage.jsx
+++ b/client/src/pages/HomePage/HomePage.jsx
@@ -84,9 +84,7 @@ const HomePage = () => {
 			{isSuccess && (
 				<div className="home-page">
 					<HomeHero homePageData={homePageData} />
-					<div className="home-page-divider-one"></div>
 					<HomeServicesSection servicesData={servicesData} />
-					{/* <div className="home-page-divider-two"></div> */}
 					<HomeEventsSection eventsData={eventsData} />
 					<HomeNewsSection newsArticlesData={newsArticlesData} />
 					<HomeGetInvolvedSection />

--- a/client/src/pages/HomePage/components/HomeEventsSection/HomeEventsSection.css
+++ b/client/src/pages/HomePage/components/HomeEventsSection/HomeEventsSection.css
@@ -3,8 +3,17 @@
 	background-color: hsl(127, 74%, 10%);
 }
 
+.home-events-title-link {
+	text-decoration: none;
+}
+
 .home-events-title {
+	text-align: center;
 	color: var(--green21);
+}
+
+.home-events-title:hover {
+	color: #b2ffab;
 }
 
 .home-events-line {

--- a/client/src/pages/HomePage/components/HomeEventsSection/HomeEventsSection.jsx
+++ b/client/src/pages/HomePage/components/HomeEventsSection/HomeEventsSection.jsx
@@ -1,4 +1,5 @@
 import "./HomeEventsSection.css";
+import { Link } from "react-router-dom";
 import Line from "../../../../components/Line/Line";
 import HomeEventCardLeft from "./components/HomeEventCardLeft/HomeEventCardLeft";
 import HomeEventCardRight from "./components/HomeEventCardRight/HomeEventCardRight";
@@ -6,7 +7,9 @@ import HomeEventCardRight from "./components/HomeEventCardRight/HomeEventCardRig
 const HomeEventsSection = ({ eventsData }) => {
 	return (
 		<section className="home-events-section">
-			<h1 className="home-events-title">Upcoming Events</h1>
+			<Link to="/events" className="home-events-title-link">
+				<h2 className="home-events-title">Upcoming Events</h2>
+			</Link>
 			<Line extraClass={"home-events-line"} />
 			<div className="home-events-container">
 				{eventsData.map((homeEvent, index) => {

--- a/client/src/pages/HomePage/components/HomeGetInvolvedSection/HomeGetInvolvedSection.css
+++ b/client/src/pages/HomePage/components/HomeGetInvolvedSection/HomeGetInvolvedSection.css
@@ -1,7 +1,4 @@
 .home-get-involved-section {
-	/* background: linear-gradient(0deg, hsl(108, 20%, 30%), var(--green09)); */
-	/* background-color: hsl(127, 74%, 10%); */
-	/* background: linear-gradient(180deg, #072c0b, #106518 25%); */
 	background-image: linear-gradient(
 		180deg,
 		hsl(126, 73%, 12%) 0%,
@@ -9,12 +6,19 @@
 	);
 	border-bottom: 6px solid var(--green12);
 	padding-top: 20px;
-	/* #08350d */
+}
+
+.home-get-involved-title-link {
+	text-decoration: none;
 }
 
 .home-get-involved-title {
 	text-align: center;
 	color: var(--green10);
+}
+
+.home-get-involved-title:hover {
+	color: #83e488;
 }
 
 .home-get-involved-line {

--- a/client/src/pages/HomePage/components/HomeGetInvolvedSection/HomeGetInvolvedSection.jsx
+++ b/client/src/pages/HomePage/components/HomeGetInvolvedSection/HomeGetInvolvedSection.jsx
@@ -6,7 +6,7 @@ import Line from "../../../../components/Line/Line";
 const HomeGetInvolvedSection = () => {
 	return (
 		<section className="home-get-involved-section">
-			<Link to="/events" className="home-get-involved-title-link">
+			<Link to="/get-involved" className="home-get-involved-title-link">
 				<h2 className="home-get-involved-title">Get Involved</h2>
 			</Link>
 			<Line extraClass={"home-get-involved-line"} />

--- a/client/src/pages/HomePage/components/HomeGetInvolvedSection/HomeGetInvolvedSection.jsx
+++ b/client/src/pages/HomePage/components/HomeGetInvolvedSection/HomeGetInvolvedSection.jsx
@@ -6,7 +6,9 @@ import Line from "../../../../components/Line/Line";
 const HomeGetInvolvedSection = () => {
 	return (
 		<section className="home-get-involved-section">
-			<h2 className="home-get-involved-title">Get Involved</h2>
+			<Link to="/events" className="home-get-involved-title-link">
+				<h2 className="home-get-involved-title">Get Involved</h2>
+			</Link>
 			<Line extraClass={"home-get-involved-line"} />
 			<div className="home-get-involved-cards-container">
 				<Link

--- a/client/src/pages/HomePage/components/HomeHero/HomeHero.css
+++ b/client/src/pages/HomePage/components/HomeHero/HomeHero.css
@@ -1,5 +1,6 @@
 .home-hero-section {
-	/* placeholder */
+	padding-bottom: 12px;
+	background-color: hsl(126, 73%, 30%);
 }
 
 .slide-container {

--- a/client/src/pages/HomePage/components/HomeNewsSection/HomeNewsSection.css
+++ b/client/src/pages/HomePage/components/HomeNewsSection/HomeNewsSection.css
@@ -1,11 +1,19 @@
 .home-news-section {
+	padding: 10px 0 15px 0;
 	background-color: var(--green10);
-	padding-bottom: 15px;
+}
+
+.home-news-title-link {
+	text-decoration: none;
 }
 
 .home-news-title {
-	margin-top: 10px;
+	text-align: center;
 	color: var(--green07);
+}
+
+.home-news-title:hover {
+	color: #1b741e;
 }
 
 .home-news-line {

--- a/client/src/pages/HomePage/components/HomeNewsSection/HomeNewsSection.jsx
+++ b/client/src/pages/HomePage/components/HomeNewsSection/HomeNewsSection.jsx
@@ -1,4 +1,5 @@
 import "./HomeNewsSection.css";
+import { Link } from "react-router-dom";
 import Line from "../../../../components/Line/Line";
 import Slider from "react-slick";
 import NewsCard from "./components/HomeNewsCard/HomeNewsCard";
@@ -38,7 +39,9 @@ const HomeNewsSection = ({ newsArticlesData }) => {
 	};
 	return (
 		<section className="home-news-section">
-			<h1 className="home-news-title">Latest News</h1>
+			<Link to="/events" className="home-news-title-link">
+				<h2 className="home-news-title">Latest News</h2>
+			</Link>
 			<Line extraClass={"home-news-line"} />
 			<Slider {...sliderSettings}>
 				{newsArticlesData.map((homeNews) => {

--- a/client/src/pages/HomePage/components/HomeNewsSection/HomeNewsSection.jsx
+++ b/client/src/pages/HomePage/components/HomeNewsSection/HomeNewsSection.jsx
@@ -39,7 +39,7 @@ const HomeNewsSection = ({ newsArticlesData }) => {
 	};
 	return (
 		<section className="home-news-section">
-			<Link to="/events" className="home-news-title-link">
+			<Link to="/news" className="home-news-title-link">
 				<h2 className="home-news-title">Latest News</h2>
 			</Link>
 			<Line extraClass={"home-news-line"} />

--- a/client/src/pages/HomePage/components/HomeServicesSection/HomeServicesSection.css
+++ b/client/src/pages/HomePage/components/HomeServicesSection/HomeServicesSection.css
@@ -10,9 +10,17 @@
 	);
 }
 
+.home-services-title-link {
+	text-decoration: none;
+}
+
 .home-services-title {
 	text-align: center;
 	color: var(--green17);
+}
+
+.home-services-title:hover {
+	color: #20441b;
 }
 
 .home-services-line {
@@ -20,9 +28,9 @@
 	/* background-color: var(--green17); */
 	background-image: linear-gradient(
 		90deg,
-		var(--green17) 0%,
-		var(--green12) 50%,
-		var(--green17) 100%
+		hsl(120, 100%, 92%) 0%,
+		hsl(113, 44%, 29%) 50%,
+		hsl(120, 100%, 92%) 100%
 	);
 }
 
@@ -35,23 +43,15 @@
 	padding-top: 30px;
 	padding-bottom: 40px;
 
-	/* background-image: linear-gradient(
-		45deg,
+	/* background-color: var(--green16); */
+	background-image: linear-gradient(
+		0deg,
 		var(--green16) 0%,
 		hsl(115deg 100% 96%) 25%,
 		hsl(115deg 100% 98%) 50%,
 		hsl(115deg 100% 96%) 75%,
 		var(--green16) 100%
-	); */
-
-	background-color: var(--green16);
-
-	/* background-image: linear-gradient(
-		180deg,
-		var(--green16) 0%,
-		hsl(115deg 100% 96%) 50%,
-		hsl(115deg 100% 98%) 100%
-	); */
+	);
 }
 
 @media screen and (min-width: 768px) {

--- a/client/src/pages/HomePage/components/HomeServicesSection/HomeServicesSection.jsx
+++ b/client/src/pages/HomePage/components/HomeServicesSection/HomeServicesSection.jsx
@@ -1,7 +1,8 @@
 import "./HomeServicesSection.css";
+import { Link } from "react-router-dom";
+import { useState, useEffect } from "react";
 import Line from "../../../../components/Line/Line";
 import HomeServiceCard from "./components/HomeServiceCard/HomeServiceCard";
-import { useState, useEffect } from "react";
 
 const HomeServicesSection = ({ servicesData }) => {
 	const [numberOfCards, setNumberOfCards] = useState(3);
@@ -29,7 +30,9 @@ const HomeServicesSection = ({ servicesData }) => {
 
 	return (
 		<section className="home-services-section">
-			<h2 className="home-services-title">Our Services</h2>
+			<Link to="/services" className="home-services-title-link">
+				<h2 className="home-services-title">Our Services</h2>
+			</Link>
 			<Line extraClass={"home-services-line"} />
 			<div className="home-services-card-list">
 				{servicesData.slice(0, numberOfCards).map((service) => {

--- a/client/src/styles/globals.css
+++ b/client/src/styles/globals.css
@@ -42,7 +42,7 @@
 	--green18: #e9ffe6;
 	--green19: #f3ffe0;
 	--green20: #39692d;
-	--green21: hsl(115, 100%, 90%);
+	--green21: #d0ffcc;
 
 	--test: #d0ffcc;
 


### PR DESCRIPTION
## Description

- Wrapped every Home Page Subheading in a Link to go to the relevant Page (not specific item)
- Added hover state colours on Links 3 (shades darker than original title)
- Adjusted the Services Line gradient to blend better
- Removed `HomePage.jsx` `<div className="divider-line-one" />` and controlled with padding on Home Hero instead

## Related to

Fixes #158

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have carefully reviewed my own code
- [X] ~I have commented my code~
- [X] ~I have updated any documentation~
