### PR TITLE
165 - Adjusted Loading Icon - Baz

### DIFF
--- a/client/src/components/LoadingIcon/LoadingIcon.css
+++ b/client/src/components/LoadingIcon/LoadingIcon.css
@@ -1,0 +1,15 @@
+.loading-icon {
+	width: 200px;
+	height: 200px;
+	margin: auto;
+	background: none;
+	display: block;
+	shape-rendering: auto;
+}
+
+@media screen and (min-width: 768px) {
+	.loading-icon {
+		width: 300px;
+		height: 300px;
+	}
+}

--- a/client/src/components/LoadingIcon/LoadingIcon.jsx
+++ b/client/src/components/LoadingIcon/LoadingIcon.jsx
@@ -1,155 +1,152 @@
-import "./LoadingIcon";
+import "./LoadingIcon.css";
 
-// this is an example of a loading icon in svg format
-// it has a size prop that determines a fixed width and height if neccessary
-// i tried to use colours somewhat similar to the project requirements, they can all be changed later
-const LoadingIcon = ({ size }) => {
+const LoadingIcon = () => {
 	return (
 		<svg
 			xmlns="http://www.w3.org/2000/svg"
 			viewBox="0 0 100 100"
 			preserveAspectRatio="xMidYMid"
-			style={size ? { width: `${size}px`, height: `${size}px` } : null}
+			className="loading-icon"
 		>
 			<g transform="rotate(0 50 50)">
-				<rect x="47" y="24" rx="3" ry="6" width="6" height="12" fill="#a0de59">
+				<rect x="46" y="21" rx="4" ry="5" width="8" height="10" fill="#269739">
 					<animate
 						attributeName="opacity"
 						values="1;0"
 						keyTimes="0;1"
-						dur="1s"
-						begin="-0.9166666666666666s"
+						dur="1.5151515151515151s"
+						begin="-1.3888888888888888s"
 						repeatCount="indefinite"
 					></animate>
 				</rect>
 			</g>
 			<g transform="rotate(30 50 50)">
-				<rect x="47" y="24" rx="3" ry="6" width="6" height="12" fill="#466b5a">
+				<rect x="46" y="21" rx="4" ry="5" width="8" height="10" fill="#f1ed0e">
 					<animate
 						attributeName="opacity"
 						values="1;0"
 						keyTimes="0;1"
-						dur="1s"
-						begin="-0.8333333333333334s"
+						dur="1.5151515151515151s"
+						begin="-1.2626262626262625s"
 						repeatCount="indefinite"
 					></animate>
 				</rect>
 			</g>
 			<g transform="rotate(60 50 50)">
-				<rect x="47" y="24" rx="3" ry="6" width="6" height="12" fill="#f5c024">
+				<rect x="46" y="21" rx="4" ry="5" width="8" height="10" fill="#b5efb8">
 					<animate
 						attributeName="opacity"
 						values="1;0"
 						keyTimes="0;1"
-						dur="1s"
-						begin="-0.75s"
+						dur="1.5151515151515151s"
+						begin="-1.1363636363636365s"
 						repeatCount="indefinite"
 					></animate>
 				</rect>
 			</g>
 			<g transform="rotate(90 50 50)">
-				<rect x="47" y="24" rx="3" ry="6" width="6" height="12" fill="#a0de59">
+				<rect x="46" y="21" rx="4" ry="5" width="8" height="10" fill="#269739">
 					<animate
 						attributeName="opacity"
 						values="1;0"
 						keyTimes="0;1"
-						dur="1s"
-						begin="-0.6666666666666666s"
+						dur="1.5151515151515151s"
+						begin="-1.0101010101010102s"
 						repeatCount="indefinite"
 					></animate>
 				</rect>
 			</g>
 			<g transform="rotate(120 50 50)">
-				<rect x="47" y="24" rx="3" ry="6" width="6" height="12" fill="#466b5a">
+				<rect x="46" y="21" rx="4" ry="5" width="8" height="10" fill="#f1ed0e">
 					<animate
 						attributeName="opacity"
 						values="1;0"
 						keyTimes="0;1"
-						dur="1s"
-						begin="-0.5833333333333334s"
+						dur="1.5151515151515151s"
+						begin="-0.8838383838383839s"
 						repeatCount="indefinite"
 					></animate>
 				</rect>
 			</g>
 			<g transform="rotate(150 50 50)">
-				<rect x="47" y="24" rx="3" ry="6" width="6" height="12" fill="#f5c024">
+				<rect x="46" y="21" rx="4" ry="5" width="8" height="10" fill="#b5efb8">
 					<animate
 						attributeName="opacity"
 						values="1;0"
 						keyTimes="0;1"
-						dur="1s"
-						begin="-0.5s"
+						dur="1.5151515151515151s"
+						begin="-0.7575757575757576s"
 						repeatCount="indefinite"
 					></animate>
 				</rect>
 			</g>
 			<g transform="rotate(180 50 50)">
-				<rect x="47" y="24" rx="3" ry="6" width="6" height="12" fill="#a0de59">
+				<rect x="46" y="21" rx="4" ry="5" width="8" height="10" fill="#269739">
 					<animate
 						attributeName="opacity"
 						values="1;0"
 						keyTimes="0;1"
-						dur="1s"
-						begin="-0.4166666666666667s"
+						dur="1.5151515151515151s"
+						begin="-0.6313131313131313s"
 						repeatCount="indefinite"
 					></animate>
 				</rect>
 			</g>
 			<g transform="rotate(210 50 50)">
-				<rect x="47" y="24" rx="3" ry="6" width="6" height="12" fill="#466b5a">
+				<rect x="46" y="21" rx="4" ry="5" width="8" height="10" fill="#f1ed0e">
 					<animate
 						attributeName="opacity"
 						values="1;0"
 						keyTimes="0;1"
-						dur="1s"
-						begin="-0.3333333333333333s"
+						dur="1.5151515151515151s"
+						begin="-0.5050505050505051s"
 						repeatCount="indefinite"
 					></animate>
 				</rect>
 			</g>
 			<g transform="rotate(240 50 50)">
-				<rect x="47" y="24" rx="3" ry="6" width="6" height="12" fill="#f5c024">
+				<rect x="46" y="21" rx="4" ry="5" width="8" height="10" fill="#b5efb8">
 					<animate
 						attributeName="opacity"
 						values="1;0"
 						keyTimes="0;1"
-						dur="1s"
-						begin="-0.25s"
+						dur="1.5151515151515151s"
+						begin="-0.3787878787878788s"
 						repeatCount="indefinite"
 					></animate>
 				</rect>
 			</g>
 			<g transform="rotate(270 50 50)">
-				<rect x="47" y="24" rx="3" ry="6" width="6" height="12" fill="#a0de59">
+				<rect x="46" y="21" rx="4" ry="5" width="8" height="10" fill="#269739">
 					<animate
 						attributeName="opacity"
 						values="1;0"
 						keyTimes="0;1"
-						dur="1s"
-						begin="-0.16666666666666666s"
+						dur="1.5151515151515151s"
+						begin="-0.25252525252525254s"
 						repeatCount="indefinite"
 					></animate>
 				</rect>
 			</g>
 			<g transform="rotate(300 50 50)">
-				<rect x="47" y="24" rx="3" ry="6" width="6" height="12" fill="#466b5a">
+				<rect x="46" y="21" rx="4" ry="5" width="8" height="10" fill="#f1ed0e">
 					<animate
 						attributeName="opacity"
 						values="1;0"
 						keyTimes="0;1"
-						dur="1s"
-						begin="-0.08333333333333333s"
+						dur="1.5151515151515151s"
+						begin="-0.12626262626262627s"
 						repeatCount="indefinite"
 					></animate>
 				</rect>
 			</g>
 			<g transform="rotate(330 50 50)">
-				<rect x="47" y="24" rx="3" ry="6" width="6" height="12" fill="#f5c024">
+				<rect x="46" y="21" rx="4" ry="5" width="8" height="10" fill="#b5efb8">
 					<animate
 						attributeName="opacity"
 						values="1;0"
 						keyTimes="0;1"
-						dur="1s"
+						dur="1.5151515151515151s"
 						begin="0s"
 						repeatCount="indefinite"
 					></animate>

--- a/client/src/pages/LoadingPage/LoadingPage.jsx
+++ b/client/src/pages/LoadingPage/LoadingPage.jsx
@@ -8,7 +8,7 @@ const LoadingPage = () => {
 			<h1 className="loading-page-title">Loading</h1>
 			<Line extraClass={"loading-page-line"} />
 			<div className="loading-page-subcontainer">
-				<LoadingIcon size={300} />
+				<LoadingIcon />
 			</div>
 		</div>
 	);


### PR DESCRIPTION
## Description

The Product Owner asked for LoadingIcon changes
- the speed should be slower
- it should use the exact colours from across the website

The LoadingIcon is 200px is Mobile and 300px in Tablet/Desktop 
And this can be adjusted from the associated css file

## Related to

Fixes #166 

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have carefully reviewed my own code
- [X] ~I have commented my code~
- [X] ~I have updated any documentation~
